### PR TITLE
`$app/env` has been renamed to `$app/environment`

### DIFF
--- a/svelte-spotlight/src/lib/SvelteSpotlight.svelte
+++ b/svelte-spotlight/src/lib/SvelteSpotlight.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { fade, scale } from 'svelte/transition';
-	import { browser } from '$app/env';
+	import { browser } from '$app/environment';
 	import {
 		type AnimationFunctions,
 		type AnimationConfig,


### PR DESCRIPTION
See https://github.com/sveltejs/kit/pull/6334

Might have to bump the SvelteKit version with this change, too. Bonus points: can we make it usable with both new and old versions?